### PR TITLE
Fixing handler return value

### DIFF
--- a/lib/QBit/WebInterface/Apache2.pm
+++ b/lib/QBit/WebInterface/Apache2.pm
@@ -44,11 +44,12 @@ sub handler : method {
     };
 
     my $status = $self->response->status;
+    $r->status($status);
 
     $self->request(undef);
     $self->response(undef);
 
-    return $status;
+    return Apache2::Const::OK;
 }
 
 sub get_cmd {


### PR DESCRIPTION
http://perl.apache.org/docs/2.0/user/handlers/intro.html#Handler_Return_Values

Hander return values are not status codes:

```
$ perl -MApache2::Const -E 'say Apache2::Const::OK;'
0
$ perl -MApache2::Const -E 'say Apache2::Const::DECLINED;'
-1
$ perl -MApache2::Const -E 'say Apache2::Const::DONE;'
-2
```
